### PR TITLE
change attribute interpolation in "head" component

### DIFF
--- a/markup/components/head/head.pug
+++ b/markup/components/head/head.pug
@@ -14,7 +14,7 @@ mixin head(data)
     |<!--[if (gt IE 9)|!(IE)]><!--><link href="%=static=%css/main%=hash=%%=min=%.css" rel="stylesheet" type="text/css"><!--<![endif]-->
 
     if data.useSocialMetaTags
-        meta(property="og:title", content="#{data.title}")
+        meta(property="og:title", content=data.title)
         meta(property="og:title", content="")
         meta(property="og:url", content="")
         meta(property="og:description", content="")


### PR DESCRIPTION
In Pug attribute interpolation syntax has been changed. So syntax like that #{data.title} does not work now.
More details in its documentation https://pugjs.org/api/migration-v2.html#attribute-interpolation